### PR TITLE
add funcSize command

### DIFF
--- a/funcSize.go
+++ b/funcSize.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+)
+
+type funcSizeRunner struct {
+	messageRE *regexp.Regexp
+}
+
+func (r *funcSizeRunner) Init() {
+	r.messageRE = regexp.MustCompile(`(.*) STEXT.* size=(\d+)`)
+}
+
+func (r *funcSizeRunner) Run(pkg string) error {
+	cmd := exec.Command("go", r.getCmd(pkg)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, out)
+	}
+
+	type resultRow struct {
+		Fn   string `json:"fn"`
+		Size string `json:"size"`
+	}
+	results := []resultRow{}
+
+	// TODO: add a CLI flag for the function name filtering?
+	// Having to use a grep in 99% of use cases is not very convenient.
+	for _, submatches := range r.messageRE.FindAllStringSubmatch(string(out), -1) {
+		results = append(results, resultRow{
+			Fn:   submatches[1],
+			Size: submatches[2],
+		})
+	}
+
+	if asJSON {
+		marshalJSON(results)
+		return nil
+	}
+
+	for _, r := range results {
+		fmt.Printf("%s: %s bytes\n", r.Fn, r.Size)
+	}
+	return nil
+}
+
+func (r *funcSizeRunner) getCmd(pkg string) []string {
+	return goArgs(pkg, goArgsBuild, goArgsGcFlags("-S"))
+}

--- a/main.go
+++ b/main.go
@@ -56,6 +56,14 @@ var cmds = []acmd.Command{
 			return run(&boundCheckRunner{})
 		},
 	},
+	{
+		Name:        "funcSize",
+		Alias:       "fsize",
+		Description: "list function machine code sizes in bytes",
+		ExecFunc: func(_ context.Context, _ []string) error {
+			return run(&funcSizeRunner{})
+		},
+	},
 }
 
 type subCommandRunner interface {


### PR DESCRIPTION
`funcSize` shows the machine code size for the functions from the specified package.

It's planned to add a function name filter later.